### PR TITLE
Fix HiredGrad's sign in modal

### DIFF
--- a/public/homepageStyle.css
+++ b/public/homepageStyle.css
@@ -9,3 +9,20 @@
 .quickLinks {
     padding: 2rem 2rem;
 }
+
+/* HiredGrad Hacks */
+#hiredGradSignUpModal {
+    overflow-y: scroll !important;
+}
+
+.iframe {
+    height: 790px !important;
+    max-width: 600px !important;
+    display: block !important;
+}
+
+@media (max-width: 524px) {
+    .iframe {
+        max-height: 680px !important;
+    }
+}


### PR DESCRIPTION
Somewhere along the way, HiredGrad changed this and broke it. Keep an eye on this for further changes.

The CSS enables the iframe to be as big as it needs to be to display all content and scrollable, so that the content can be seen. The media query is neccessary as the content inexplicably shrinks below this resolution and leaving the iframe at 790px height results in a nasty white bar at the bottom of the modal. This is only fixable by changing the internal iframe code which we can't do as this is a cross origin request. The compromise is to make the iframe shorter (which removes the functionality to sign into a previously created account on moblie).