### PR TITLE
Use padding to space footer copyright notice

### DIFF
--- a/public/indexStyle.css
+++ b/public/indexStyle.css
@@ -72,15 +72,11 @@ object {
 
 .footer {
     background-color: #333;
-    display: flex;
     min-height: 5em;
     color: #9d9d9d;
     text-align:center;
     height: auto;
-}
-
-.footer div {
-    max-width: 70%;
+    padding: 1em;
 }
 
 .footer p {


### PR DESCRIPTION
Makes the footer look better on mobile and removes the need for flexbox which was probably broken in some places anyway.